### PR TITLE
Be more verbose with AutoHDR instrucitions for games

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Download reshade with full add-on support [here](https://reshade.me/downloads/Re
 [![HDRLAUNCHOPTION.png](https://i.postimg.cc/SNpXbkbm/HDRLAUNCHOPTION.png)](https://postimg.cc/grNcv907)
 
 
-➡️ In the game press **"Home"** keyboard key to open reshade.
+➡️ In the game press **"Home"** keyboard key to open reshade. If `AdvancedAutoHDR.fx` failed to compile, use `protontricks` to install `d3dcompiler` into the games prefix.
 
 ➡️ Go the the **addon** section : 
 


### PR DESCRIPTION
Hello,

When using this guide for running a game with AutoHDR I ran into a problem, where Pumbos autohdr shader would not compile. I turned to the HDR Den Discord server where i was told that I need to install `d3dcompiler47`. That fixed my problem and now everything works.

I added this to the Guide.

Cheers